### PR TITLE
Fix AI chatbot 401 error by protecting /chat route

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
 # Database
 DATABASE_URL="postgresql://user:password@localhost:5432/weddingplan"
 
-# NextAuth
-NEXTAUTH_URL="http://localhost:3000"
-NEXTAUTH_SECRET="generate-random-secret-here-use-openssl-rand-base64-32"
+# Supabase Authentication
+NEXT_PUBLIC_SUPABASE_URL="https://your-project.supabase.co"
+NEXT_PUBLIC_SUPABASE_ANON_KEY="your-anon-key-here"
 
 # Claude API
 ANTHROPIC_API_KEY="sk-ant-your-key-here"

--- a/middleware.ts
+++ b/middleware.ts
@@ -8,7 +8,12 @@ export async function middleware(request: NextRequest) {
   let response = await updateSession(request)
 
   // Protected routes - require authentication
-  if (request.nextUrl.pathname.startsWith('/dashboard')) {
+  const protectedRoutes = ['/dashboard', '/chat']
+  const isProtectedRoute = protectedRoutes.some(route =>
+    request.nextUrl.pathname.startsWith(route)
+  )
+
+  if (isProtectedRoute) {
     const supabase = createServerClient(
       getEnvVar('NEXT_PUBLIC_SUPABASE_URL'),
       getEnvVar('NEXT_PUBLIC_SUPABASE_ANON_KEY'),


### PR DESCRIPTION
## Summary
- Add `/chat` to protected routes in middleware alongside `/dashboard`
- Users now redirected to login when accessing chat unauthenticated
- Update `.env.example` to use Supabase auth variables instead of NextAuth

## Root Cause
The chat page was accessible without authentication, but the chat API endpoint requires authentication. This caused 401 errors when unauthenticated users tried to send messages.

## Testing
- Verified middleware now protects both `/dashboard` and `/chat` routes
- Confirmed `.env.example` contains correct Supabase variables

Fixes #4

Generated with [Claude Code](https://claude.ai/code)